### PR TITLE
Get tox working with requirements listed in setup.py

### DIFF
--- a/pip_numpy_first.sh
+++ b/pip_numpy_first.sh
@@ -1,0 +1,4 @@
+#/bin/bash
+# This is a hack to work around https://github.com/tox-dev/tox/issues/42
+
+pip install numpy && pip "$@"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@ numpy
 pandas
 psycopg2
 dedupe
+dedupe-variable-name
+PyYAML
+click

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,9 @@ requirements = [
     'psycopg2',
     'numpy',
     'pandas',
-    # TODO: add 'dedupe'!
+    'PyYAML',
+    'dedupe',
+    'dedupe-variable-name',
 ]
 
 test_requirements = [
@@ -24,7 +26,7 @@ test_requirements = [
 setup(
     name='superdeduper',
     version='0.1.0',
-    description="A simple interface to datamade/dedupe e to make probabilistic record linkage easy.",
+    description="A simple interface to datamade/dedupe to make probabilistic record linkage easy.",
     long_description=readme + '\n\n' + history,
     author="DSaPP Researchers",
     author_email='datascifellows@gmail.com',

--- a/tox.ini
+++ b/tox.ini
@@ -7,15 +7,13 @@ deps=flake8
 commands=flake8 superdeduper
 
 [testenv]
+install_command = bash {toxinidir}/pip_numpy_first.sh install {opts} {packages}
 commands =
-    pip install -U pip
-    pip install numpy
-    pip install -r {toxinidir}/requirements_dev.txt
     py.test --basetemp={envtmpdir}
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/superdeduper
-; deps =
-;     -r{toxinidir}/requirements_dev.txt
+deps =
+    -r{toxinidir}/requirements_dev.txt
 
 [flake8]
 max-line-length = 99


### PR DESCRIPTION
This is hacky, but I think it's the best way to go for now.  Basic summary:

When requirements get listed in `setup.py`, they get installed when pip installs superdeduper into the virtual env.  Tox does this with the `install_command` option, which defaults to `pip install {opts} {packages}`.  When this happens, all the requirements listed in `setup.py` get installed simultaneously. But numpy is required to already be installed by one of the dependencies (`fastcluster`).

As far as I can tell, there's no way to get tox to do something before the `install_command`.  You can disable the install_command entirely and just do all the setup in `commands`, but in that context the special `{packages}` syntax is no longer expanded.