### PR TITLE
Require Dedupe 1.6.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ requirements = [
     'numpy',
     'pandas',
     'PyYAML',
-    'dedupe',
+    'dedupe>=1.6.0',
     'dedupe-variable-name',
 ]
 


### PR DESCRIPTION
I believe this is the version where `max_comparisons` was no longer a common issue.